### PR TITLE
Fix LICENSE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Then run `make doc`.
 
 ## License
 
-Awsm is released under the [ISC license](./LICENSE).
+Awsm is released under the [MIT license](./LICENSE.md).
 
 
 ## How to contribute


### PR DESCRIPTION
First of all thank you for releasing what looks like a great library. When looking through the code I noticed the license link was incorrect and named the ISC rather than MIT. 